### PR TITLE
Make $ProcessObjects non-mandatory

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -5511,7 +5511,7 @@ Function Get-RunningProcesses {
 #>
 	[CmdletBinding()]
 	Param (
-		[Parameter(Mandatory=$true,Position=0)]
+		[Parameter(Mandatory=$false,Position=0)]
 		[psobject[]]$ProcessObjects,
 		[Parameter(Mandatory=$false,Position=1)]
 		[switch]$DisableLogging


### PR DESCRIPTION
Proposed fix for issue 328 https://github.com/PSAppDeployToolkit/PSAppDeployToolkit/issues/328